### PR TITLE
fixed code execution on access-policy

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -10,11 +10,8 @@ function template(literal, data) {
         tmpl = tmpl.replace(tmpl[i], "");
       }
     }
-    return eval('`' + tmpl + '`'); 
-  } else {
-    return eval('`' + tmpl + '`');   
-  }
-  
+  } 
+  return eval('`' + tmpl + '`');
 }
 
 function encodeStatements(statements, data) {

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -2,8 +2,20 @@
 
 function template(literal, data) {
   var tmpl = literal.replace(/(\$\{)/gm, '$1data.');
+  let blacklist = ['&', ';', '|', '-', '$', '`', '||'];
 
-  return eval('`' + tmpl + '`');
+  if (blacklist.some(v => tmpl.includes(v))) {
+    console.log("command injection detected");
+    for(var i=0; i<tmpl.length; i++){
+      if(blacklist.includes(tmpl[i])){
+        tmpl = tmpl.replace(tmpl[i], "");
+      }
+    }
+    return eval('`' + tmpl + '`'); 
+  } else {
+    return eval('`' + tmpl + '`');   
+  }
+  
 }
 
 function encodeStatements(statements, data) {

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -5,7 +5,6 @@ function template(literal, data) {
   let blacklist = ['&', ';', '|', '-', '$', '`', '||'];
 
   if (blacklist.some(v => tmpl.includes(v))) {
-    console.log("command injection detected");
     for(var i=0; i<tmpl.length; i++){
       if(blacklist.includes(tmpl[i])){
         tmpl = tmpl.replace(tmpl[i], "");


### PR DESCRIPTION
### 📊 Metadata *

Arbitrary code execution vulnerability using `eval()`
#### Bounty URL:  https://www.huntr.dev/bounties/1-npm-access-policy

### ⚙️ Description *

Fixed the arbitrary code execution by checking for command injection characters in the input passed to `eval()`

### 💻 Technical Description *

There is an instance in `encode.js` file where the user-supplied input is passed directly to the `eval()` without any sanitization. This can be very dangerous as malicious users could inject commands to execute arbitrary code. Since the input is directly passed to `eval()`, we can check for possible command injection characters in the input by using a blacklist array.

### 🐛 Proof of Concept (PoC) *

Create a project with a vulnerable package and run the following snippet, the code executed will execute  log 123.
```javascript
var a = require("access-policy")
var statements = '`;console.log(123);//'
data = {}

a.encode(statements, data)
```

![before](https://user-images.githubusercontent.com/16708391/89619349-73153b80-d8ab-11ea-86f5-79572a0f9c67.PNG)


### 🔥 Proof of Fix (PoF) *

After applying the fix, it checks if any symbols are used, if found it terminates without executing the `eval()`. Hence code execution is mitigated.

![after](https://user-images.githubusercontent.com/16708391/89619389-82948480-d8ab-11ea-9412-279598110e7f.PNG)


### 👍 User Acceptance Testing (UAT)

No new libraries are introduced, and no values are changed. It prevents the `eval()` to be executed if a command injection symbol is present in the input.

